### PR TITLE
feat: add blog deletion functionality with confirmation modal

### DIFF
--- a/blogapp/templates/blogapp/blog_confirm_delete.html
+++ b/blogapp/templates/blogapp/blog_confirm_delete.html
@@ -1,0 +1,43 @@
+{% extends 'blogapp/blog_detail.html' %}
+{% block content %}
+{{ block.super }}  <!-- This displays the parent template's content -->
+
+<div id="deleteConfirmModal" class="fixed inset-0 z-50 flex items-center justify-center overflow-auto bg-black bg-opacity-50" tabindex="-1" role="dialog">
+    <div class="relative mx-auto p-4 w-full max-w-md">
+        <div class="bg-white rounded-lg shadow-lg">
+            <div class="flex items-center justify-between p-4 border-b">
+                <h5 class="text-lg font-medium">Confirm Deletion</h5>
+                <button type="button" class="text-gray-500 hover:text-gray-700" id="closeModal">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="p-4">
+                <p class="mb-2">Are you sure you want to delete "{{ object.title }}"?</p>
+                <p>This action cannot be undone.</p>
+            </div>
+            <div class="flex justify-end p-4 border-t">
+                <form method="post" class="flex space-x-2">
+                    {% csrf_token %}
+                    <button type="button" id="cancelButton" class="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300">Cancel</button>
+                    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">Delete</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Show modal on page load
+        document.getElementById('deleteConfirmModal').classList.remove('hidden');
+        // Handle close button
+        document.getElementById('closeModal').addEventListener('click', function() {
+            window.history.back();
+        });
+        // Handle cancel button to redirect back
+        document.getElementById('cancelButton').addEventListener('click', function() {
+            window.history.back();
+        });
+    });
+</script>
+{% endblock %}

--- a/blogapp/templates/blogapp/blog_detail.html
+++ b/blogapp/templates/blogapp/blog_detail.html
@@ -1,8 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
   {% if user.is_authenticated and user == object.author %}
-    <div class="flex justify-start mb-4">
+    <div class="flex justify-start mb-4 space-x-4">
       <a href="{% url 'blogapp:edit_blog' object.pk %}" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors animate-fade-in">Edit</a>
+      <a href="{% url 'blogapp:delete_blog' object.pk %}" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded transition-colors animate-fade-in" data-toggle="modal" data-target="#deleteConfirmModal">Delete</a>
     </div>
   {% endif %}
   <article class="bg-white dark:bg-gray-900 p-6 rounded-lg shadow-lg transition-all duration-700 ease-in-out dark:text-white text-gray-900 animate-fade-in">

--- a/blogapp/urls.py
+++ b/blogapp/urls.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import views as auth_views
 from django.urls import path, include
-from .views import BlogListView, BlogDetailView, ReviewCreateView, CommentCreateView, BlogCreateView, BlogUpdateView, login_view, logout_view, sign_up
+from .views import BlogListView, BlogDetailView, ReviewCreateView, CommentCreateView, BlogCreateView, BlogUpdateView, BlogDeleteView, login_view, logout_view, sign_up
 
 app_name = 'blogapp'
 
@@ -13,6 +13,7 @@ urlpatterns = [
     path('logout/', logout_view, name='logout'),
     path('blog/add/', BlogCreateView.as_view(), name='add_blog'),
     path('blog/<int:pk>/edit/', BlogUpdateView.as_view(), name='edit_blog'),
+    path('blog/<int:pk>/delete/', BlogDeleteView.as_view(), name='delete_blog'),
     path('blog/<int:pk>/', BlogDetailView.as_view(), name='blog_detail'),
     path('blog/<int:pk>/review/', ReviewCreateView.as_view(), name='add_review'),
     path('blog/<int:blog_pk>/review/<int:review_pk>/comment/', CommentCreateView.as_view(), name='add_comment'),

--- a/blogapp/views.py
+++ b/blogapp/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login, logout
 from .forms import UserRegisterForm
 from django.contrib import messages
-from django.views.generic import ListView, DetailView, CreateView, UpdateView
+from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView
 from django.urls import reverse_lazy
 from .models import Blog, Review, Comment
 
@@ -52,6 +52,15 @@ class BlogUpdateView(LoginRequiredMixin, UpdateView):
 
     def get_success_url(self):
         return reverse_lazy('blogapp:blog_detail', kwargs={'pk': self.object.pk})
+
+class BlogDeleteView(LoginRequiredMixin, DeleteView):
+    model = Blog
+    template_name = 'blogapp/blog_confirm_delete.html'
+    success_url = reverse_lazy('blogapp:blog_list')
+
+    def delete(self, request, *args, **kwargs):
+        messages.success(request, f'The Blog has been deleted successfully!')
+        return super().delete(request, *args, **kwargs)
 
 class ReviewCreateView(LoginRequiredMixin, CreateView):
     model = Review


### PR DESCRIPTION
This pull request introduces a feature to allow users to delete blog posts, including the addition of a confirmation modal for deletion. The changes span templates, views, and URL configurations to implement and integrate the new functionality.

### Template Updates:
* Added a new `blog_confirm_delete.html` template to display a confirmation modal for blog deletion, including JavaScript to handle modal behavior and navigation. (`blogapp/templates/blogapp/blog_confirm_delete.html`)
* Updated the `blog_detail.html` template to include a "Delete" button for blog posts authored by the logged-in user, linking to the deletion confirmation modal. (`blogapp/templates/blogapp/blog_detail.html`)

### View Enhancements:
* Introduced a `BlogDeleteView` class in `views.py`, extending `DeleteView` to handle blog deletion with a success message and redirecting to the blog list upon deletion. (`blogapp/views.py`) [[1]](diffhunk://#diff-b6ab9bf0c2a35f5a18dbfaf973c48458ddd9b5f18c5ea204f542037e2bc9ad8bL7-R7) [[2]](diffhunk://#diff-b6ab9bf0c2a35f5a18dbfaf973c48458ddd9b5f18c5ea204f542037e2bc9ad8bR56-R64)

### URL Configuration:
* Added a new URL pattern for the `BlogDeleteView` to handle deletion requests. (`blogapp/urls.py`) [[1]](diffhunk://#diff-5a0dbc3feae3d9a103b4a1769e3cc5e1177c2dfd3fc21d15f6dd05ecde071963L3-R3) [[2]](diffhunk://#diff-5a0dbc3feae3d9a103b4a1769e3cc5e1177c2dfd3fc21d15f6dd05ecde071963R16)